### PR TITLE
Update genlayer-js to v0.18.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ __pycache__/
 *.pyc
 *.pyo
 *.pyd
+deploy/deployScript.compiled.js
+/context

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,7 +8,7 @@
       "name": "app",
       "version": "0.0.0",
       "dependencies": {
-        "genlayer-js": "^0.13.0",
+        "genlayer-js": "^0.18.3",
         "lucide-vue-next": "^0.446.0",
         "vue": "^3.4.37"
       },
@@ -2530,9 +2530,9 @@
       }
     },
     "node_modules/genlayer-js": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-0.13.0.tgz",
-      "integrity": "sha512-1kLLEqaaDcrfxTERQnBsNkO6tCiwvbKSnxI7I07on1abmgY+K4l4E0CettUFFdUDGpItEaIltc4rrpD8T3e4HQ==",
+      "version": "0.18.3",
+      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-0.18.3.tgz",
+      "integrity": "sha512-idTGq7Uzt88/oFAm9uKr0sZUdwDEVdgw18cqn+/VooA47cH3B4degpVY8nDsK0g1msg5cDXzLBD3T4yD/esVrA==",
       "license": "MIT",
       "dependencies": {
         "eslint-plugin-import": "^2.30.0",

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "genlayer-js": "^0.13.0",
+    "genlayer-js": "^0.18.3",
     "lucide-vue-next": "^0.446.0",
     "vue": "^3.4.37"
   },

--- a/contracts/football_bets.py
+++ b/contracts/football_bets.py
@@ -28,7 +28,7 @@ class FootballBets(gl.Contract):
 
     def _check_match(self, resolution_url: str, team1: str, team2: str) -> dict:
         def get_match_result() -> str:
-            web_data = gl.get_webpage(resolution_url, mode="text")
+            web_data = gl.nondet.web.render(resolution_url, mode="text")
 
             task = f"""
 Extract the match result for:
@@ -48,10 +48,10 @@ nothing else. Don't include any other words or characters,
 your output must be only JSON without any formatting prefix or suffix.
 This result should be perfectly parsable by a JSON parser without errors.
         """
-            result = gl.exec_prompt(task).replace("```json", "").replace("```", "")
-            return json.dumps(json.loads(result), sort_keys=True)
+            result = gl.nondet.exec_prompt(task, response_format="json")
+            return json.dumps(result, sort_keys=True)
 
-        result_json = json.loads(gl.eq_principle_strict_eq(get_match_result))
+        result_json = json.loads(gl.eq_principle.strict_eq(get_match_result))
         return result_json
 
     @gl.public.write

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,13 @@
     "": {
       "name": "genlayer-project",
       "devDependencies": {
-        "genlayer-js": "^0.6.0"
+        "genlayer-js": "^0.18.3"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
-      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -224,14 +224,27 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/curves": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.7.1"
+        "@noble/hashes": "1.8.0"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -241,9 +254,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -261,9 +274,9 @@
       "license": "MIT"
     },
     "node_modules/@scure/base": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
-      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -271,29 +284,29 @@
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
-      "integrity": "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~1.8.1",
-        "@noble/hashes": "~1.7.1",
-        "@scure/base": "~1.2.2"
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
-      "integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "~1.7.1",
-        "@scure/base": "~1.2.4"
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -323,9 +336,9 @@
       "license": "MIT"
     },
     "node_modules/abitype": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
-      "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.1.0.tgz",
+      "integrity": "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -333,7 +346,7 @@
       },
       "peerDependencies": {
         "typescript": ">=5.0.4",
-        "zod": "^3 >=3.22.0"
+        "zod": "^3.22.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -1403,15 +1416,15 @@
       }
     },
     "node_modules/genlayer-js": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-0.6.4.tgz",
-      "integrity": "sha512-tbsBRyVUGZ0a+661ML6wu3U3p5CtHkik7a4qTc68OZgf1pX1G4JBs7CzAmqAkMt8HUyD/J413raDs9Q5s3psWw==",
+      "version": "0.18.3",
+      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-0.18.3.tgz",
+      "integrity": "sha512-idTGq7Uzt88/oFAm9uKr0sZUdwDEVdgw18cqn+/VooA47cH3B4degpVY8nDsK0g1msg5cDXzLBD3T4yD/esVrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-plugin-import": "^2.30.0",
         "typescript-parsec": "^0.3.4",
-        "viem": "^2.21.7"
+        "viem": "^2.29.0"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2063,9 +2076,9 @@
       "peer": true
     },
     "node_modules/isows": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
-      "integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
       "dev": true,
       "funding": [
         {
@@ -2363,9 +2376,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.7.tgz",
-      "integrity": "sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.6.tgz",
+      "integrity": "sha512-8SuCbHPvv2eZLYXrNmC0EC12rdzXQLdhnOMlHDW2wiCPLxBrOOJwX5L5E61by+UjTPOryqQiRSnjIKCI+GykKg==",
       "dev": true,
       "funding": [
         {
@@ -2375,12 +2388,13 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@adraffy/ens-normalize": "^1.10.1",
-        "@noble/curves": "^1.6.0",
-        "@noble/hashes": "^1.5.0",
-        "@scure/bip32": "^1.5.0",
-        "@scure/bip39": "^1.4.0",
-        "abitype": "^1.0.6",
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.0.9",
         "eventemitter3": "5.0.1"
       },
       "peerDependencies": {
@@ -3045,9 +3059,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.23.5",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.23.5.tgz",
-      "integrity": "sha512-cUfBHdFQHmBlPW0loFXda0uZcoU+uJw3NRYQRwYgkrpH6PgovH8iuVqDn6t1jZk82zny4wQL54c9dCX2W9kLMg==",
+      "version": "2.38.6",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.38.6.tgz",
+      "integrity": "sha512-aqO6P52LPXRjdnP6rl5Buab65sYa4cZ6Cpn+k4OLOzVJhGIK8onTVoKMFMT04YjDfyDICa/DZyV9HmvLDgcjkw==",
       "dev": true,
       "funding": [
         {
@@ -3057,14 +3071,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "1.8.1",
-        "@noble/hashes": "1.7.1",
-        "@scure/bip32": "1.6.2",
-        "@scure/bip39": "1.5.4",
-        "abitype": "1.0.8",
-        "isows": "1.0.6",
-        "ox": "0.6.7",
-        "ws": "8.18.0"
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.1.0",
+        "isows": "1.0.7",
+        "ox": "0.9.6",
+        "ws": "8.18.3"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -3192,9 +3206,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "genlayer-project",
   "type": "module",
   "devDependencies": {
-    "genlayer-js": "^0.9.1"
+    "genlayer-js": "^0.18.3"
   }
 }


### PR DESCRIPTION
## Summary
- Updated genlayer-js to v0.18.3
- Migrated contract to use new API methods (gl.nondet.web.render, gl.nondet.exec_prompt, gl.eq_principle.strict_eq)
- Updated .gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated genlayer-js library dependency to version ^0.18.3 across project configurations
  * Updated deployment and build configuration entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->