### PR TITLE
fix(deploy): fail on execution errors instead of printing a dead contract address

### DIFF
--- a/deploy/deployScript.ts
+++ b/deploy/deployScript.ts
@@ -9,6 +9,11 @@ import {
 } from "genlayer-js/types";
 import { localnet } from "genlayer-js/chains";
 
+// TODO: Once genlayer-js v2 ships, migrate this deploy flow to:
+// - waitUntil: "decided"
+// - isSuccessful(receipt)
+// - explicit fee options
+
 export default async function main(client: GenLayerClient<any>) {
   const filePath = path.resolve(process.cwd(), "contracts/football_bets.py");
 
@@ -35,6 +40,36 @@ export default async function main(client: GenLayerClient<any>) {
       receipt.statusName !== "FINALIZED"
     ) {
       throw new Error(`Deployment failed. Receipt: ${JSON.stringify(receipt)}`);
+    }
+
+    const receiptWithExecution = receipt as typeof receipt & {
+      txExecutionResultName?: string;
+      tx_execution_result_name?: string;
+      consensus_data?: {
+        leader_receipt?:
+          | { execution_result?: string }
+          | Array<{ execution_result?: string }>;
+      };
+    };
+    const leaderReceipt = Array.isArray(
+      receiptWithExecution.consensus_data?.leader_receipt,
+    )
+      ? receiptWithExecution.consensus_data?.leader_receipt[0]
+      : receiptWithExecution.consensus_data?.leader_receipt;
+    const executionResult =
+      receiptWithExecution.txExecutionResultName ??
+      receiptWithExecution.tx_execution_result_name ??
+      leaderReceipt?.execution_result;
+
+    if (
+      executionResult !== "SUCCESS" &&
+      executionResult !== "FINISHED_WITH_RETURN"
+    ) {
+      throw new Error(
+        `Deployment execution failed. Status: ${
+          receipt.statusName ?? receipt.status
+        }; execution result: ${executionResult ?? "missing"}.`,
+      );
     }
 
     const deployedContractAddress =

--- a/tests/direct/conftest.py
+++ b/tests/direct/conftest.py
@@ -10,6 +10,9 @@ def to_hex(addr_bytes):
     """
     if hasattr(addr_bytes, "as_hex"):
         return addr_bytes.as_hex
-    from genlayer.py.types import Address
+    try:
+        from genlayer.types import Address
+    except ImportError:
+        from genlayer.py.types import Address
 
     return Address(addr_bytes).as_hex


### PR DESCRIPTION
From the fee audit: the deploy script checked only consensus status, so an ACCEPTED-but-FINISHED_WITH_ERROR deploy printed a contract address that would never work — and this is the scaffold new users copy.

- After the status check, the script now requires a successful execution result (Studio `leader_receipt.execution_result == SUCCESS`, or forward-compatible `txExecutionResultName == FINISHED_WITH_RETURN`); exits non-zero with status + result otherwise. No new SDK APIs (works with the pinned genlayer-js 1.1.8); a TODO documents the v2 migration (`waitUntil`/`isSuccessful`/fee options) once it ships.
- `tests/direct/conftest.py`: GenVM v0.3 SDK layout added to the Address import fallback chain.

Note: the SDK/gltest version pins stay untouched on purpose — they're blocked on the genlayer-js v2 / CLI 0.40 / gltest 0.30 releases (release-sequencing item in the audit).