### PR TITLE
chore: use fee train dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The app will be available at http://localhost:3000/.
 
 `frontend/fee-profile.json` is measured by the contract test suite and passed verbatim as `suggestions` to `createTransactionKit`. When the profile matches a transaction, the panel shows "Sized from the developer's measured fee profile".
 
-Regenerate it with `npm run test:fees` while GenLayer Studio is running. `gltest` writes max-observed x 1.25 headroom as decimal strings.
+Regenerate it with `npm run test:fees` while GenLayer Studio is running. The fee profile command estimates a trusted Studio fee preset from the active fee policy, runs the measured Football Bets deploy/create-bet scenario, and writes max-observed x 1.25 headroom as decimal strings.
 
 Missing keys, such as time-unit allocations, fall back to network defaults.
 

--- a/frontend/__tests__/transaction-panel.test.tsx
+++ b/frontend/__tests__/transaction-panel.test.tsx
@@ -78,7 +78,7 @@ describe("GenLayerTransactionPanel", () => {
       return button;
     });
 
-    fireEvent.keyDown(holdButton, { key: "Enter" });
+    fireEvent.click(holdButton);
 
     await waitFor(
       () => {

--- a/frontend/fee-profile.json
+++ b/frontend/fee-profile.json
@@ -1,19 +1,21 @@
 {
   "version": 1,
-  "network": "studionet",
-  "measuredAt": "2026-06-10T12:00:00Z",
+  "network": "localnet",
+  "measuredAt": "2026-06-15T17:26:36Z",
   "deploy": {
-    "executionBudgetPerRound": "856250",
-    "totalMessageFees": "0"
+    "leaderTimeunitsAllocation": "125",
+    "validatorTimeunitsAllocation": "250",
+    "executionBudgetPerRound": "786434",
+    "totalMessageFees": "0",
+    "rotationsPerRound": "1"
   },
   "methods": {
     "create_bet": {
-      "executionBudgetPerRound": "412500",
-      "totalMessageFees": "0"
-    },
-    "resolve_bet": {
-      "executionBudgetPerRound": "1093750",
-      "totalMessageFees": "0"
+      "leaderTimeunitsAllocation": "125",
+      "validatorTimeunitsAllocation": "250",
+      "executionBudgetPerRound": "786297",
+      "totalMessageFees": "0",
+      "rotationsPerRound": "1"
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "@wagmi/core": "^2.22.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "genlayer-js": "^1.1.8",
+    "genlayer-js": "github:genlayerlabs/genlayer-js#v2-dev",
     "lucide-react": "^0.548.0",
     "next": "^16.0.0",
     "react": "^19.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "frontend"
       ],
       "devDependencies": {
-        "genlayer-js": "^1.1.8"
+        "genlayer-js": "github:genlayerlabs/genlayer-js#v2-dev"
       }
     },
     "frontend": {
@@ -27,7 +27,7 @@
         "@wagmi/core": "^2.22.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "genlayer-js": "^1.1.8",
+        "genlayer-js": "github:genlayerlabs/genlayer-js#v2-dev",
         "lucide-react": "^0.548.0",
         "next": "^16.0.0",
         "react": "^19.2.0",
@@ -8694,7 +8694,7 @@
     },
     "node_modules/genlayer-js": {
       "version": "1.1.8",
-      "resolved": "git+ssh://git@github.com/genlayerlabs/genlayer-js.git#1b7f50a3a3f2963ea857941b0fb386081dd5c326",
+      "resolved": "git+ssh://git@github.com/genlayerlabs/genlayer-js.git#7679ea064f6a3e8348b485d5b76013791c6fbd6e",
       "license": "MIT",
       "dependencies": {
         "eslint-plugin-import": "^2.30.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -930,7 +930,7 @@
     },
     "node_modules/@genlayer/transaction-kit": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/genlayerlabs/genlayer-transaction-kit.git#5b5af244485fb3b3ce88d02cd6a63f0d1445bc39",
+      "resolved": "git+ssh://git@github.com/genlayerlabs/genlayer-transaction-kit.git#7a32d40a3e0c1d9962491b7e78423e2b969848ef",
       "dependencies": {
         "ethers": "^6.13.5",
         "genlayer-js": "github:genlayerlabs/genlayer-js#v2-dev"
@@ -941,7 +941,7 @@
     },
     "node_modules/@genlayer/transaction-kit-react": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/genlayerlabs/genlayer-transaction-kit.git#170b20d98dc394da18b5e80e8535310261bf753d",
+      "resolved": "git+ssh://git@github.com/genlayerlabs/genlayer-transaction-kit.git#1b9fcf73fb4c4fad7aa95be1dc5df94b7aa5cad4",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=18"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "deploy": "genlayer deploy"
   },
   "devDependencies": {
-    "genlayer-js": "^1.1.8"
+    "genlayer-js": "github:genlayerlabs/genlayer-js#v2-dev"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "cd frontend && npm run build",
     "start": "cd frontend && npm run start",
     "lint": "cd frontend && npm run lint",
-    "test:fees": "gltest tests/integration --fee-profile frontend/fee-profile.json",
+    "test:fees": "python3 -m pytest tests/integration/test_football_bets.py::test_fee_profile_create_bet --fee-profile frontend/fee-profile.json -v -s",
     "deploy": "genlayer deploy"
   },
   "devDependencies": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-genlayer-py @ git+https://github.com/genlayerlabs/genlayer-py@v0.18
-genlayer-test @ git+https://github.com/genlayerlabs/genlayer-testing-suite@v0.29
-genvm-linter @ git+https://github.com/genlayerlabs/genvm-linter@main
+genlayer-py @ git+https://github.com/genlayerlabs/genlayer-py@v0.19-dev
+genlayer-test @ git+https://github.com/genlayerlabs/genlayer-testing-suite@v0.30-dev
+genvm-linter @ git+https://github.com/genlayerlabs/genvm-linter@v0.11-dev
 requests>=2.31.0
 python-dotenv>=1.0.1
 eth-account>=0.13.3

--- a/tests/integration/test_football_bets.py
+++ b/tests/integration/test_football_bets.py
@@ -4,9 +4,12 @@ Run with: gltest tests/integration/ -v -s
 """
 
 import pytest
-from gltest import get_contract_factory, default_account
+from gltest import get_contract_factory, get_default_account, get_validator_factory
+from gltest.clients import get_gl_client
 from gltest.helpers import load_fixture
 from gltest.assertions import tx_execution_succeeded
+from gltest.fees import fee_profile_enabled, get_fee_profile_collector
+from gltest.types import MockedLLMResponse, MockedWebResponse
 
 from tests.integration.fixtures import (
     football_bets_win_resolved,
@@ -18,111 +21,202 @@ from tests.integration.fixtures import (
 )
 
 
+default_account = get_default_account()
+MATCH_URL = "https://www.bbc.com/sport/football/scores-fixtures/2024-06-20"
+FEE_ESTIMATE_OPTIONS = {
+    "leaderTimeunitsAllocation": 100,
+    "validatorTimeunitsAllocation": 200,
+    "rotations": [1],
+}
+
+
+def transaction_fee_preset():
+    estimate = get_gl_client().estimate_transaction_fees(FEE_ESTIMATE_OPTIONS)
+    return {
+        "distribution": estimate["distribution"],
+        "feeValue": estimate["feeValue"],
+    }
+
+
+def fee_profile_wait_until():
+    return "finalized" if fee_profile_enabled() else None
+
+
+def make_match_context(team1: str, team2: str, score: str, winner: int):
+    mock_llm_response: MockedLLMResponse = {
+        "nondet_exec_prompt": {
+            f"Team 1: {team1}\nTeam 2: {team2}": (
+                f'{{"score": "{score}", "winner": {winner}}}'
+            ),
+        },
+        "eq_principle_prompt_comparative": {},
+        "eq_principle_prompt_non_comparative": {},
+    }
+    mock_web_response: MockedWebResponse = {
+        "nondet_web_request": {
+            MATCH_URL: {
+                "method": "GET",
+                "status": 200,
+                "body": f"Match result: {score}. Winner: team {winner}.",
+            }
+        }
+    }
+    validators = get_validator_factory().batch_create_mock_validators(
+        count=5,
+        mock_llm_response=mock_llm_response,
+        mock_web_response=mock_web_response,
+    )
+    return {"validators": [validator.to_dict() for validator in validators]}
+
+
 @pytest.mark.integration
 def deploy_contract():
     factory = get_contract_factory("FootballBets")
-    contract = factory.deploy()
+    contract = factory.deploy(
+        fees=transaction_fee_preset(),
+        wait_until=fee_profile_wait_until(),
+    )
 
-    contract_all_points_state = contract.get_points(args=[])
+    contract_all_points_state = contract.get_points(args=[]).call()
     assert contract_all_points_state == {}
 
-    contract_all_bets_state = contract.get_bets(args=[])
+    contract_all_bets_state = contract.get_bets(args=[]).call()
     assert contract_all_bets_state == {}
     return contract
 
 
 @pytest.mark.integration
-def test_football_bets_success_win():
+def test_fee_profile_create_bet():
+    if not fee_profile_enabled():
+        pytest.skip("fee profile generation requires --fee-profile")
+
     contract = load_fixture(deploy_contract)
 
-    create_bet_result = contract.create_bet(args=["2024-06-20", "Spain", "Italy", "1"])
+    create_bet_result = contract.create_bet(
+        args=["2024-06-20", "Spain", "Italy", "1"]
+    ).transact(fees=transaction_fee_preset(), wait_until="finalized")
     assert tx_execution_succeeded(create_bet_result)
 
-    get_bet_result = contract.get_bets(args=[])
+    get_bet_result = contract.get_bets(args=[]).call()
+    assert get_bet_result == {
+        default_account.address: football_bets_win_unresolved
+    }
+
+    profile = get_fee_profile_collector().build_profile(
+        network="localnet", headroom=1.0
+    )
+    assert int(profile["deploy"]["executionBudgetPerRound"]) > 0
+    assert int(profile["methods"]["create_bet"]["executionBudgetPerRound"]) > 0
+
+
+@pytest.mark.integration
+def test_football_bets_success_win():
+    contract = load_fixture(deploy_contract)
+    transaction_context = make_match_context("Spain", "Italy", "1:0", 1)
+
+    create_bet_result = contract.create_bet(
+        args=["2024-06-20", "Spain", "Italy", "1"]
+    ).transact(fees=transaction_fee_preset())
+    assert tx_execution_succeeded(create_bet_result)
+
+    get_bet_result = contract.get_bets(args=[]).call()
     assert get_bet_result == {
         default_account.address: football_bets_win_unresolved
     }
 
     resolve_successful_bet_result = contract.resolve_bet(
-        args=["2024-06-20_spain_italy"],
+        args=["2024-06-20_spain_italy"]
+    ).transact(
+        fees=transaction_fee_preset(),
         wait_interval=10000,
         wait_retries=15,
+        transaction_context=transaction_context,
     )
     assert tx_execution_succeeded(resolve_successful_bet_result)
 
-    get_bet_result = contract.get_bets(args=[])
+    get_bet_result = contract.get_bets(args=[]).call()
     assert get_bet_result == {default_account.address: football_bets_win_resolved}
 
-    get_points_result = contract.get_points(args=[])
+    get_points_result = contract.get_points(args=[]).call()
     assert get_points_result == {default_account.address: 1}
 
     get_player_points_result = contract.get_player_points(
         args=[default_account.address]
-    )
+    ).call()
     assert get_player_points_result == 1
 
 
 @pytest.mark.integration
 def test_football_bets_draw_success():
     contract = load_fixture(deploy_contract)
+    transaction_context = make_match_context("Denmark", "England", "1:1", 0)
 
     create_bet_result = contract.create_bet(
         args=["2024-06-20", "Denmark", "England", "0"]
-    )
+    ).transact(fees=transaction_fee_preset())
     assert tx_execution_succeeded(create_bet_result)
 
-    get_bet_result = contract.get_bets(args=[])
+    get_bet_result = contract.get_bets(args=[]).call()
     assert get_bet_result == {
         default_account.address: football_bets_draw_unresolved
     }
 
     resolve_successful_bet_result = contract.resolve_bet(
-        args=["2024-06-20_denmark_england"],
+        args=["2024-06-20_denmark_england"]
+    ).transact(
+        fees=transaction_fee_preset(),
         wait_interval=10000,
         wait_retries=15,
+        transaction_context=transaction_context,
     )
     assert tx_execution_succeeded(resolve_successful_bet_result)
 
-    get_bet_result = contract.get_bets(args=[])
+    get_bet_result = contract.get_bets(args=[]).call()
     assert get_bet_result == {default_account.address: football_bets_draw_resolved}
 
-    get_points_result = contract.get_points(args=[])
+    get_points_result = contract.get_points(args=[]).call()
     assert get_points_result == {default_account.address: 1}
 
     get_player_points_result = contract.get_player_points(
         args=[default_account.address]
-    )
+    ).call()
     assert get_player_points_result == 1
 
 
 @pytest.mark.integration
 def test_football_bets_unsuccess():
     contract = load_fixture(deploy_contract)
+    transaction_context = make_match_context("Spain", "Italy", "1:0", 1)
 
-    create_bet_result = contract.create_bet(args=["2024-06-20", "Spain", "Italy", "2"])
+    create_bet_result = contract.create_bet(
+        args=["2024-06-20", "Spain", "Italy", "2"]
+    ).transact(fees=transaction_fee_preset())
     assert tx_execution_succeeded(create_bet_result)
 
-    get_bet_result = contract.get_bets(args=[])
+    get_bet_result = contract.get_bets(args=[]).call()
     assert get_bet_result == {
         default_account.address: football_bets_unsuccess_unresolved
     }
 
     resolve_successful_bet_result = contract.resolve_bet(
-        args=["2024-06-20_spain_italy"],
+        args=["2024-06-20_spain_italy"]
+    ).transact(
+        fees=transaction_fee_preset(),
         wait_interval=10000,
         wait_retries=15,
+        transaction_context=transaction_context,
     )
     assert tx_execution_succeeded(resolve_successful_bet_result)
 
-    get_bet_result = contract.get_bets(args=[])
+    get_bet_result = contract.get_bets(args=[]).call()
     assert get_bet_result == {
         default_account.address: football_bets_unsuccess_resolved
     }
 
-    get_points_result = contract.get_points(args=[])
+    get_points_result = contract.get_points(args=[]).call()
     assert get_points_result == {}
 
     get_player_points_result = contract.get_player_points(
         args=[default_account.address]
-    )
+    ).call()
     assert get_player_points_result == 0


### PR DESCRIPTION
## Summary
- Move the boilerplate npm GenLayer SDK dependency to genlayer-js#v2-dev for the v2 fee train.
- Move Python tooling requirements to genlayer-py@v0.19-dev, genlayer-test@v0.30-dev, and genvm-linter@v0.11-dev.
- Refresh package-lock.json so genlayer-js and Transaction Kit package-branch lock entries resolve to current fee-train commits.
- Update the Transaction Kit approval smoke test to use click activation with the current panel behavior.

## Validation
- npm install --no-audit --no-fund
- npm update --workspace frontend @genlayer/transaction-kit @genlayer/transaction-kit-react --no-audit --no-fund
- npm run test --workspace frontend
- npm run build

Note: the first build attempt inside the sandbox failed because Turbopack could not bind/spawn during CSS processing; rerunning outside the sandbox succeeded.