### PR TITLE
Validate winner range in resolve_bet

### DIFF
--- a/contracts/football_bets.py
+++ b/contracts/football_bets.py
@@ -41,7 +41,7 @@ Web content:
 Respond in JSON:
 {{
     "score": str, // e.g., "1:2" or "-" if unresolved
-    "winner": int // 0 for draw, -1 if unresolved
+    "winner": int // 0 for draw, 1 if Team 1 won, 2 if Team 2 won, -1 if unresolved
 }}
 It is mandatory that you respond only using the JSON format above,
 nothing else. Don't include any other words or characters,
@@ -94,8 +94,15 @@ This result should be perfectly parsable by a JSON parser without errors.
         bet = self.bets[gl.message.sender_address][bet_id]
         bet_status = self._check_match(bet.resolution_url, bet.team1, bet.team2)
 
-        if int(bet_status["winner"]) < 0:
+        winner = int(bet_status["winner"])
+        if winner < 0:
             raise Exception("Game not finished")
+        # The prompt defines the full accepted value space: 0 = draw,
+        # 1 = team1, 2 = team2 (and -1 = unresolved, handled above).
+        # Reject anything outside it so a malformed extraction can never be
+        # stored or scored against a prediction.
+        if winner > 2:
+            raise Exception("Invalid match result")
 
         bet.has_resolved = True
         bet.real_winner = str(bet_status["winner"])

--- a/tests/direct/test_resolve_bet.py
+++ b/tests/direct/test_resolve_bet.py
@@ -95,6 +95,18 @@ def test_resolve_unfinished_game_fails(direct_vm, direct_deploy, direct_alice):
         contract.resolve_bet("2024-06-20_spain_italy")
 
 
+def test_resolve_out_of_range_winner_fails(direct_vm, direct_deploy, direct_alice):
+    """An LLM-extracted winner outside {-1, 0, 1, 2} must be rejected, not stored."""
+    contract = direct_deploy("contracts/football_bets.py")
+    direct_vm.sender = direct_alice
+
+    contract.create_bet("2024-06-20", "Spain", "Italy", "1")
+    _setup_match_mocks(direct_vm, "9:9", 3)
+
+    with direct_vm.expect_revert("Invalid match result"):
+        contract.resolve_bet("2024-06-20_spain_italy")
+
+
 def test_multiple_users_resolve_independently(
     direct_vm, direct_deploy, direct_alice, direct_bob
 ):


### PR DESCRIPTION
## Summary

Adds an upper-bound validation to the bet-resolution path in the intelligent contract, plus a direct test. Targets `v2-dev` per the repo branch policy.

### Validate the winner value range (`contracts/football_bets.py`)

`resolve_bet` validated only the lower sentinel:

```python
if int(bet_status["winner"]) < 0:
    raise Exception("Game not finished")
```

…but never an upper bound. Because the extracted result is stored with
`bet.real_winner = str(bet_status["winner"])` and then compared to
`predicted_winner`, a malformed extraction such as `{"winner": 3}` was
**stored and scored** against the prediction with no rejection — a silent
wrong outcome. The presence of the existing `< 0` check shows value
validation was intended here; it was simply incomplete.

Changes:
- Add `if winner > 2: raise Exception("Invalid match result")`.
- Define the full value space in the LLM prompt — previously it documented
  only `0` (draw) and `-1` (unresolved); `1`/`2` were left to inference even
  though the contract and UI depend on them.
- Add `test_resolve_out_of_range_winner_fails` (direct mode).

## Testing

- `pytest tests/direct/ -v`
- `genvm-lint check contracts/football_bets.py`

## Scope note

This started as a two-part change (contract validation + surfacing contract
revert reasons in the frontend). On `v2-dev` the frontend write path has been
refactored onto `@genlayer/transaction-kit-react`, so the original
`FootballBets.ts` catch-block that discarded revert reasons no longer exists —
that fix is moot here and has been dropped. Only the contract-side change,
which applies cleanly to `v2-dev`, remains.
