### PR TITLE
docs: fix star-chart badge to point to this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Discord](https://img.shields.io/badge/Discord-Join%20us-5865F2?logo=discord&logoColor=white)](https://discord.gg/8Jm4v89VAu)
 [![Telegram](https://img.shields.io/badge/Telegram--T.svg?style=social&logo=telegram)](https://t.me/genlayer)
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/yeagerai.svg?style=social&label=Follow%20%40GenLayer)](https://x.com/GenLayer)
-[![GitHub star chart](https://img.shields.io/github/stars/yeagerai/genlayer-project-boilerplate?style=social)](https://star-history.com/#yeagerai/genlayer-js)
+[![GitHub star chart](https://img.shields.io/github/stars/genlayerlabs/genlayer-project-boilerplate?style=social)](https://star-history.com/#genlayerlabs/genlayer-project-boilerplate)
 
 ## About
 This project includes the boilerplate code for a GenLayer use case implementation, specifically a football bets game.


### PR DESCRIPTION
## Problem

The **GitHub star chart** badge in the README references the wrong repository in two ways:

```md
[![GitHub star chart](https://img.shields.io/github/stars/yeagerai/genlayer-project-boilerplate?style=social)](https://star-history.com/#yeagerai/genlayer-js)
```

- The **badge** counts stars for `yeagerai/genlayer-project-boilerplate`, but the repo now lives at **`genlayerlabs/genlayer-project-boilerplate`**.
- The **link** points to `star-history.com/#yeagerai/genlayer-js` — an **unrelated** project (`genlayer-js`), not this boilerplate.

So the badge shows a stale star count and clicking it takes readers to the wrong project's star history.

## Fix

Point both the badge and the link at this repository:

```diff
-[![GitHub star chart](https://img.shields.io/github/stars/yeagerai/genlayer-project-boilerplate?style=social)](https://star-history.com/#yeagerai/genlayer-js)
+[![GitHub star chart](https://img.shields.io/github/stars/genlayerlabs/genlayer-project-boilerplate?style=social)](https://star-history.com/#genlayerlabs/genlayer-project-boilerplate)
```

Single-line docs fix, no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s GitHub star chart badge to reference the new repository URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->