### PR TITLE
fix: align boilerplate contracts with GenVM v0.6

### DIFF
--- a/contracts/PatternTest.py
+++ b/contracts/PatternTest.py
@@ -1,25 +1,23 @@
-# { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 """
 PatternTest.py — Minimal contract to test GenLayer patterns.
 Covers: gl.vm.Return, partial field matching, u256 arithmetic,
 Address constructor, json.dumps sort_keys, nested TreeMap workaround.
 """
 import json
-from genlayer import *
-import genlayer.gl.vm as glvm
+import genlayer as gl
 
 
-class PatternTest(gl.Contract):
+class PatternTest(gl.contract.Contract):
     # Pattern 4: u256 storage
-    count: u256
-    amount: u256
+    count: gl.u256
+    amount: gl.u256
     # Pattern 7: nested TreeMap workaround (list stored as JSON string)
-    index: TreeMap[str, str]
+    index: gl.storage.TreeMap[str, str]
 
-    def __init__(self, initial_amount: u256 = u256(0)):
-        self.count = u256(0)
-        self.amount = u256(int(initial_amount))
-        self.index = TreeMap()
+    def __init__(self, initial_amount: gl.u256 = gl.u256(0)):
+        self.count = gl.u256(0)
+        self.amount = gl.u256(int(initial_amount))
 
     # ── Pattern 1 & 2: gl.vm.Return type check + partial field matching ──────
 
@@ -39,7 +37,7 @@ class PatternTest(gl.Contract):
 
         def validator_fn(leader_result) -> bool:
             # Pattern 1: isinstance check
-            if not isinstance(leader_result, glvm.Return):
+            if not isinstance(leader_result, gl.vm.Return):
                 return False
             # Pattern 2: partial field matching — only compare winner + score
             v = leader_fn()
@@ -48,30 +46,30 @@ class PatternTest(gl.Contract):
                 and leader_result.calldata["score"] == v["score"]
             )
 
-        result = glvm.run_nondet_unsafe(leader_fn, validator_fn)
+        result = gl.vm.run_nondet(leader_fn, validator_fn)
         return result
 
     @gl.public.write
     def get_match_result_raises(self) -> dict:
         """Leader fn raises — validator should see non-Return (UserError)."""
         def leader_fn() -> dict:
-            raise Exception("LLM failed")
+            raise gl.vm.UserError("LLM failed")
 
         def validator_fn(leader_result) -> bool:
             # If leader raised, leader_result should NOT be a Return
-            if not isinstance(leader_result, glvm.Return):
+            if not isinstance(leader_result, gl.vm.Return):
                 return False  # correct: error case
             return True
 
-        result = glvm.run_nondet_unsafe(leader_fn, validator_fn)
+        result = gl.vm.run_nondet(leader_fn, validator_fn)
         return result
 
     # ── Pattern 4: u256 arithmetic ────────────────────────────────────────────
 
     @gl.public.write
-    def increment(self) -> u256:
+    def increment(self) -> gl.u256:
         """Increment count by 1 using u256(int(self.count) + 1)."""
-        self.count = u256(int(self.count) + 1)
+        self.count = gl.u256(int(self.count) + 1)
         return self.count
 
     @gl.public.view
@@ -88,7 +86,7 @@ class PatternTest(gl.Contract):
     def set_party(self, party_b: str) -> str:
         """Accepts str address, wraps in Address constructor."""
         if isinstance(party_b, (str, bytes)):
-            party_b = Address(party_b)
+            party_b = gl.Address(party_b)
         return str(party_b)
 
     # ── Pattern 6: json.dumps sort_keys ──────────────────────────────────────

--- a/contracts/football_bets.py
+++ b/contracts/football_bets.py
@@ -1,8 +1,9 @@
-# { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import json
 from dataclasses import dataclass
-from genlayer import *
+import genlayer as gl
+from genlayer.storage import allow as allow_storage
 
 
 @allow_storage
@@ -19,9 +20,9 @@ class Bet:
     real_score: str
 
 
-class FootballBets(gl.Contract):
-    bets: TreeMap[Address, TreeMap[str, Bet]]
-    points: TreeMap[Address, u256]
+class FootballBets(gl.contract.Contract):
+    bets: gl.storage.TreeMap[gl.Address, gl.storage.TreeMap[str, Bet]]
+    points: gl.storage.TreeMap[gl.Address, gl.u256]
 
     def __init__(self):
         pass
@@ -71,7 +72,7 @@ This result should be perfectly parsable by a JSON parser without errors.
 
         bet_id = f"{game_date}_{team1}_{team2}".lower()
         if sender_address in self.bets and bet_id in self.bets[sender_address]:
-            raise Exception("Bet already created")
+            raise gl.vm.UserError("Bet already created")
 
         bet = Bet(
             id=bet_id,
@@ -89,20 +90,20 @@ This result should be perfectly parsable by a JSON parser without errors.
     @gl.public.write
     def resolve_bet(self, bet_id: str) -> None:
         if self.bets[gl.message.sender_address][bet_id].has_resolved:
-            raise Exception("Bet already resolved")
+            raise gl.vm.UserError("Bet already resolved")
 
         bet = self.bets[gl.message.sender_address][bet_id]
         bet_status = self._check_match(bet.resolution_url, bet.team1, bet.team2)
 
         winner = int(bet_status["winner"])
         if winner < 0:
-            raise Exception("Game not finished")
+            raise gl.vm.UserError("Game not finished")
         # The prompt defines the full accepted value space: 0 = draw,
         # 1 = team1, 2 = team2 (and -1 = unresolved, handled above).
         # Reject anything outside it so a malformed extraction can never be
         # stored or scored against a prediction.
         if winner > 2:
-            raise Exception("Invalid match result")
+            raise gl.vm.UserError("Invalid match result")
 
         bet.has_resolved = True
         bet.real_winner = str(bet_status["winner"])
@@ -123,4 +124,4 @@ This result should be perfectly parsable by a JSON parser without errors.
 
     @gl.public.view
     def get_player_points(self, player_address: str) -> int:
-        return self.points.get(Address(player_address), 0)
+        return self.points.get(gl.Address(player_address), 0)

--- a/tests/direct/conftest.py
+++ b/tests/direct/conftest.py
@@ -1,5 +1,7 @@
 """Shared helpers for direct mode tests."""
 
+import json
+
 
 def to_hex(addr_bytes):
     """Convert address bytes to checksummed hex matching contract output.
@@ -10,6 +12,11 @@ def to_hex(addr_bytes):
     """
     if hasattr(addr_bytes, "as_hex"):
         return addr_bytes.as_hex
-    from genlayer.py.types import Address
+    from genlayer.types import Address
 
     return Address(addr_bytes).as_hex
+
+
+def mock_json_llm(vm, prompt_pattern, response):
+    """Register JSON at the direct runner's raw text response boundary."""
+    vm.mock_llm(prompt_pattern, json.dumps(json.dumps(response)))

--- a/tests/direct/test_patterns.py
+++ b/tests/direct/test_patterns.py
@@ -10,6 +10,8 @@ import json
 import pytest
 from pathlib import Path
 
+from tests.direct.conftest import mock_json_llm
+
 CONTRACT_PATH = "contracts/PatternTest.py"
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -108,7 +110,7 @@ class TestGlVmReturn:
         isinstance(leader_result, gl.vm.Return) → True.
         """
         # Mock LLM so leader_fn doesn't fail
-        direct_vm.mock_llm(r".*", '{"winner": 1, "score": "2:1"}')
+        mock_json_llm(direct_vm, r".*", {"winner": 1, "score": "2:1"})
         contract = direct_deploy(CONTRACT_PATH)
         # Should succeed — validator sees Return, returns True → consensus
         result = contract.get_match_result(True)
@@ -120,12 +122,12 @@ class TestGlVmReturn:
         """
         When leader raises, validator_fn receives UserError (not Return).
         isinstance(leader_result, gl.vm.Return) → False.
-        The validator returns False on error, which causes run_nondet_unsafe to fail.
+        The validator returns False on error, which causes run_nondet to fail.
         """
-        direct_vm.mock_llm(r".*", '{"winner": 1}')
+        mock_json_llm(direct_vm, r".*", {"winner": 1})
         contract = direct_deploy(CONTRACT_PATH)
         # get_match_result_raises: leader always raises, validator returns False
-        # run_nondet_unsafe should raise/revert since validator returns False
+        # run_nondet should raise/revert since validator returns False
         from gltest.direct import ContractRollback
         with pytest.raises((ContractRollback, Exception)):
             contract.get_match_result_raises()
@@ -140,7 +142,7 @@ class TestPartialFieldMatching:
         Validator only checks winner + score.
         Consensus reached even though 'analysis' varies.
         """
-        direct_vm.mock_llm(r".*", '{"winner": 1, "score": "2:1"}')
+        mock_json_llm(direct_vm, r".*", {"winner": 1, "score": "2:1"})
         contract = direct_deploy(CONTRACT_PATH)
         result = contract.get_match_result(True)
         assert result["winner"] == 1
@@ -150,7 +152,7 @@ class TestPartialFieldMatching:
 
     def test_partial_match_team2_wins(self, direct_vm, direct_deploy):
         """Partial matching also works for team2 wins scenario."""
-        direct_vm.mock_llm(r".*", '{"winner": 2, "score": "0:3"}')
+        mock_json_llm(direct_vm, r".*", {"winner": 2, "score": "0:3"})
         contract = direct_deploy(CONTRACT_PATH)
         result = contract.get_match_result(False)
         assert result["winner"] == 2

--- a/tests/direct/test_resolve_bet.py
+++ b/tests/direct/test_resolve_bet.py
@@ -1,8 +1,6 @@
 """Tests for bet resolution — requires web + LLM mocks."""
 
-import json
-
-from tests.direct.conftest import to_hex
+from tests.direct.conftest import mock_json_llm, to_hex
 
 
 def _setup_match_mocks(vm, score, winner):
@@ -11,9 +9,10 @@ def _setup_match_mocks(vm, score, winner):
         r".*bbc\.com/sport/football/scores-fixtures.*",
         {"status": 200, "body": f"Match result: {score}. Winner: team {winner}."},
     )
-    vm.mock_llm(
+    mock_json_llm(
+        vm,
         r".*Extract the match result.*",
-        json.dumps({"score": score, "winner": winner}),
+        {"score": score, "winner": winner},
     )
 
 

--- a/tests/direct/test_v2_dev_sdk_compat.py
+++ b/tests/direct/test_v2_dev_sdk_compat.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from gltest.direct.sdk_compat import import_calldata, import_types
+from gltest.direct.sdk_loader import setup_sdk_paths
+
+
+def test_pinned_direct_runner_exports_modules_expected_by_genlayer_test():
+    """The pinned runner and test harness must agree on the v0.3 SDK layout."""
+    contract = Path("contracts/football_bets.py").resolve()
+    setup_sdk_paths(contract, None)
+
+    assert hasattr(import_calldata(), "encode")
+    assert hasattr(import_types(), "Address")

--- a/tests/direct/test_views.py
+++ b/tests/direct/test_views.py
@@ -1,8 +1,6 @@
 """Tests for read-only view methods."""
 
-import json
-
-from tests.direct.conftest import to_hex
+from tests.direct.conftest import mock_json_llm, to_hex
 
 
 def test_empty_bets(direct_deploy):
@@ -35,9 +33,10 @@ def test_points_accumulate(direct_vm, direct_deploy, direct_alice):
         r".*bbc\.com/sport/football/scores-fixtures.*",
         {"status": 200, "body": "Match results available."},
     )
-    direct_vm.mock_llm(
+    mock_json_llm(
+        direct_vm,
         r".*Extract the match result.*",
-        json.dumps({"score": "1:0", "winner": 1}),
+        {"score": "1:0", "winner": 1},
     )
     contract.resolve_bet("2024-06-20_spain_italy")
 
@@ -47,9 +46,10 @@ def test_points_accumulate(direct_vm, direct_deploy, direct_alice):
         r".*bbc\.com/sport/football/scores-fixtures.*",
         {"status": 200, "body": "Match results available."},
     )
-    direct_vm.mock_llm(
+    mock_json_llm(
+        direct_vm,
         r".*Extract the match result.*",
-        json.dumps({"score": "1:1", "winner": 0}),
+        {"score": "1:1", "winner": 0},
     )
     contract.resolve_bet("2024-06-20_denmark_england")
 


### PR DESCRIPTION
## What

Fixes the confirmed v2-dev runner/test-harness incompatibility and retains its regression coverage.

The boilerplate requirements use `genlayer-test` v0.30, while both contracts still used the old SDK layout. This change:

- pins both contracts to the concrete GenVM `v0.6.0-rc0` runner hash `9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0`
- migrates contract, storage, nondeterministic execution, and user-error APIs to the matching SDK surface
- removes invalid TreeMap constructor initialization
- adapts direct JSON mocks to the v0.30 raw-text boundary without changing business assertions

## Validation

- Compatibility regression: passed
- Focused resolve-bet suite: 7 passed
- Full direct suite: 45 passed
- `genvm-lint check` on both contracts: lint and validation passed
- `git diff --check`