### PR TITLE
fix: reject undetermined contract deployments

### DIFF
--- a/deploy/deployScript.ts
+++ b/deploy/deployScript.ts
@@ -2,12 +2,24 @@ import { readFileSync } from "fs";
 import path from "path";
 import {
   TransactionHash,
-  TransactionStatus,
   GenLayerClient,
   DecodedDeployData,
   GenLayerChain,
 } from "genlayer-js/types";
 import { localnet } from "genlayer-js/chains";
+
+export const isSuccessfulDeploymentReceipt = (receipt: {
+  status?: number | string;
+  statusName?: string;
+}): boolean => {
+  const numericStatus = Number(receipt.status);
+  return (
+    numericStatus === 5 ||
+    numericStatus === 7 ||
+    receipt.statusName === "ACCEPTED" ||
+    receipt.statusName === "FINALIZED"
+  );
+};
 
 export default async function main(client: GenLayerClient<any>) {
   const filePath = path.resolve(process.cwd(), "contracts/football_bets.py");
@@ -24,23 +36,22 @@ export default async function main(client: GenLayerClient<any>) {
 
     const receipt = await client.waitForTransactionReceipt({
       hash: deployTransaction as TransactionHash,
-      status: TransactionStatus.ACCEPTED,
+      waitUntil: "decided",
       retries: 200,
     });
 
-    if (
-      receipt.status !== 5 &&
-      receipt.status !== 6 &&
-      receipt.statusName !== "ACCEPTED" &&
-      receipt.statusName !== "FINALIZED"
-    ) {
+    if (!isSuccessfulDeploymentReceipt(receipt)) {
       throw new Error(`Deployment failed. Receipt: ${JSON.stringify(receipt)}`);
     }
 
     const deployedContractAddress =
       (client.chain as GenLayerChain).id === localnet.id
-        ? receipt.data.contract_address
+        ? receipt.data?.contract_address
         : (receipt.txDataDecoded as DecodedDeployData)?.contractAddress;
+
+    if (!deployedContractAddress) {
+      throw new Error("Deployment receipt did not contain a contract address");
+    }
 
     console.log(`Contract deployed at address: ${deployedContractAddress}`);
   } catch (error) {

--- a/frontend/__tests__/deploy-script.test.ts
+++ b/frontend/__tests__/deploy-script.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { isSuccessfulDeploymentReceipt } from "../../deploy/deployScript";
+
+describe("deployment receipt success", () => {
+  it("does not treat UNDETERMINED as a successful deployment", () => {
+    expect(
+      isSuccessfulDeploymentReceipt({
+        status: 6,
+        statusName: "UNDETERMINED",
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts only accepted or finalized decisions", () => {
+    expect(isSuccessfulDeploymentReceipt({ status: 5 })).toBe(true);
+    expect(isSuccessfulDeploymentReceipt({ statusName: "FINALIZED" })).toBe(
+      true,
+    );
+    expect(
+      isSuccessfulDeploymentReceipt({ statusName: "LEADER_TIMEOUT" }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- wait for a decided deployment result
- accept only ACCEPTED or FINALIZED receipts
- require a deployed contract address and add status regression coverage

## Verification
- focused Vitest suite (2 passed)
- TypeScript check