### PR TITLE
fix: prevent post-hoc football bets

### DIFF
--- a/contracts/football_bets.py
+++ b/contracts/football_bets.py
@@ -1,9 +1,62 @@
 # { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
+import datetime
 import json
 from dataclasses import dataclass
 import genlayer as gl
 from genlayer.storage import allow as allow_storage
+
+_ASCII_DIGITS = frozenset("0123456789")
+_DATE_SEPARATORS = frozenset("Tt ")
+_MINUTES_PER_DAY = 24 * 60
+
+_UNREADABLE = -1
+"""Sentinel for a timestamp that could not be read, returned instead of raising."""
+
+
+def _is_iso_date(value: str) -> bool:
+    """True iff `value` is exactly an ASCII `YYYY-MM-DD` date.
+
+    `datetime.date.fromisoformat` also accepts the basic `YYYYMMDD` form, so the
+    accepted spelling of a fixture is pinned here rather than left to the parser.
+    """
+    if len(value) != 10 or value[4] != "-" or value[7] != "-":
+        return False
+    digits = value[0:4] + value[5:7] + value[8:10]
+    return all(char in _ASCII_DIGITS for char in digits)
+
+
+def _midnight_minutes(date: datetime.date) -> int:
+    """Midnight UTC on `date`, as whole minutes from a fixed epoch."""
+    return date.toordinal() * _MINUTES_PER_DAY
+
+
+def _utc_minutes_of(timestamp: str) -> int:
+    """`timestamp` as whole minutes from that epoch in UTC, else `_UNREADABLE`.
+
+    RFC 3339 permits a UTC offset and the message spec does not pin one, so the
+    date the VM writes is not necessarily the UTC date: `2024-06-19T20:00:00-05:00`
+    is already 2024-06-20 in UTC. Passing an explicit target zone keeps
+    `astimezone` pure arithmetic; a naive value is read as UTC instead, since
+    `astimezone` would otherwise resolve it against the host's local zone.
+    """
+    if len(timestamp) > 10 and timestamp[10] not in _DATE_SEPARATORS:
+        # `fromisoformat` takes any single separator character; RFC 3339 does not.
+        return _UNREADABLE
+    if timestamp.endswith("z"):
+        # RFC 3339 allows a lower-case designator; `fromisoformat` does not.
+        timestamp = timestamp[:-1] + "Z"
+
+    try:
+        moment = datetime.datetime.fromisoformat(timestamp)
+    except ValueError:
+        return _UNREADABLE
+
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=datetime.timezone.utc)
+    moment = moment.astimezone(datetime.timezone.utc)
+
+    return _midnight_minutes(moment.date()) + moment.hour * 60 + moment.minute
 
 
 @allow_storage
@@ -55,18 +108,45 @@ This result should be perfectly parsable by a JSON parser without errors.
         result_json = json.loads(gl.eq_principle.strict_eq(get_match_result))
         return result_json
 
+    def _assert_betting_open(self, game_date: str) -> None:
+        """Reject a bet placed on or after the day of the fixture.
+
+        Day granularity is all the existing interface offers: `game_date` is a
+        bare date, no kickoff time is accepted or stored anywhere, and `bet_id`
+        identifies a fixture by date and teams alone. Closing bets at the start
+        of the match day is therefore the latest deadline that is still
+        certainly pre-match for every fixture the oracle page lists for that
+        date.
+
+        `gl.message.raw["datetime"]` is the transaction time supplied by
+        consensus, so the deadline is enforced without any non-deterministic
+        call: `create_bet` stays deterministic and cheap. Both sides are reduced
+        to a minute count so that the offset the VM may have written is handled
+        by subtraction, with no date rollover to special-case.
+        """
+        if not _is_iso_date(game_date):
+            raise gl.vm.UserError("Invalid game date, expected YYYY-MM-DD")
+        try:
+            kickoff_day = datetime.date.fromisoformat(game_date)
+        except ValueError:
+            raise gl.vm.UserError("Invalid game date, expected YYYY-MM-DD")
+
+        now = _utc_minutes_of(gl.message.raw["datetime"])
+        if now == _UNREADABLE:
+            raise gl.vm.UserError("Invalid transaction time")
+
+        if now >= _midnight_minutes(kickoff_day):
+            raise gl.vm.UserError("Betting closed for this game")
+
     @gl.public.write
     def create_bet(
         self, game_date: str, team1: str, team2: str, predicted_winner: str
     ) -> None:
+        self._assert_betting_open(game_date)
+
         match_resolution_url = (
             "https://www.bbc.com/sport/football/scores-fixtures/" + game_date
         )
-        # commented to allow to test matches in the past.
-        # match_status = await self._check_match(match_resolution_url, team1, team2)
-
-        # if int(match_status["winner"]) > -1:
-        #    raise Exception("Game already finished")
 
         sender_address = gl.message.sender_address
 

--- a/tests/direct/conftest.py
+++ b/tests/direct/conftest.py
@@ -2,6 +2,15 @@
 
 import json
 
+PRE_MATCH_CLOCK = "2024-06-19T12:00:00Z"
+"""Transaction time for tests that bet on the 2024-06-20 fixtures.
+
+`create_bet` refuses bets placed on or after the fixture's match day, so tests
+have to place the transaction clock before it. Direct mode injects
+`gl.message.raw["datetime"]` when the contract is deployed, which means
+`direct_vm.warp()` only takes effect if it runs *before* `direct_deploy()`.
+"""
+
 
 def to_hex(addr_bytes):
     """Convert address bytes to checksummed hex matching contract output.

--- a/tests/direct/test_bet_deadline.py
+++ b/tests/direct/test_bet_deadline.py
@@ -1,0 +1,299 @@
+"""Regression tests for F-01 — bets must be placed before the match day.
+
+`create_bet` used to accept any `game_date`, so a player could read a finished
+result off the oracle page, create the matching bet and resolve it immediately
+for a guaranteed point. The deadline is now enforced deterministically from
+`gl.message.raw["datetime"]` (the consensus-supplied transaction time, normalised
+to UTC), so `create_bet` still makes no non-deterministic call.
+
+Direct mode injects the transaction time into the contract when it is deployed,
+so `direct_vm.warp()` must be called *before* `direct_deploy()`.
+"""
+
+import pytest
+
+from tests.direct.conftest import PRE_MATCH_CLOCK, mock_json_llm, to_hex
+
+GAME_DATE = "2024-06-20"
+
+# Same calendar day as GAME_DATE, after full time.
+AFTER_FULL_TIME_CLOCK = "2024-06-20T22:00:00Z"
+
+# Days after GAME_DATE.
+LONG_AFTER_CLOCK = "2024-07-01T09:00:00Z"
+
+
+def _mock_finished_match(vm, score, winner):
+    """Mock the oracle reporting a finished match."""
+    vm.mock_web(
+        r".*bbc\.com/sport/football/scores-fixtures.*",
+        {"status": 200, "body": f"Full time. Score {score}."},
+    )
+    mock_json_llm(
+        vm,
+        r".*Extract the match result.*",
+        {"score": score, "winner": winner},
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The exploit: bet on a result you already know
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_cannot_create_bet_once_match_day_has_started(
+    direct_vm, direct_deploy, direct_alice
+):
+    """The audit's F-01 chain: known result -> create_bet -> resolve -> point."""
+    direct_vm.warp(AFTER_FULL_TIME_CLOCK)
+    contract = direct_deploy("contracts/football_bets.py")
+    direct_vm.sender = direct_alice
+    alice = to_hex(direct_alice)
+
+    # Alice has already read the full-time result off the oracle page.
+    _mock_finished_match(direct_vm, "1:0", 1)
+
+    with direct_vm.expect_revert("Betting closed for this game"):
+        contract.create_bet(GAME_DATE, "Spain", "Italy", "1")
+
+    assert contract.get_bets() == {}
+    assert contract.get_player_points(alice) == 0
+
+
+def test_cannot_create_bet_days_after_the_match(
+    direct_vm, direct_deploy, direct_alice
+):
+    direct_vm.warp(LONG_AFTER_CLOCK)
+    contract = direct_deploy("contracts/football_bets.py")
+    direct_vm.sender = direct_alice
+
+    with direct_vm.expect_revert("Betting closed for this game"):
+        contract.create_bet(GAME_DATE, "Spain", "Italy", "1")
+
+
+def test_post_hoc_bet_cannot_be_resolved(direct_vm, direct_deploy, direct_alice):
+    """No bet is stored, so the resolve half of the exploit has nothing to score."""
+    direct_vm.warp(AFTER_FULL_TIME_CLOCK)
+    contract = direct_deploy("contracts/football_bets.py")
+    direct_vm.sender = direct_alice
+    alice = to_hex(direct_alice)
+
+    _mock_finished_match(direct_vm, "1:0", 1)
+
+    with direct_vm.expect_revert("Betting closed for this game"):
+        contract.create_bet(GAME_DATE, "Spain", "Italy", "1")
+
+    with direct_vm.expect_revert():
+        contract.resolve_bet("2024-06-20_spain_italy")
+
+    assert contract.get_player_points(alice) == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Legitimate pre-match betting still works
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_pre_match_bet_is_accepted_and_resolves(
+    direct_vm, direct_deploy, direct_alice
+):
+    direct_vm.warp(PRE_MATCH_CLOCK)
+    contract = direct_deploy("contracts/football_bets.py")
+    direct_vm.sender = direct_alice
+    alice = to_hex(direct_alice)
+
+    contract.create_bet(GAME_DATE, "Spain", "Italy", "1")
+
+    bet = contract.get_bets()[alice]["2024-06-20_spain_italy"]
+    assert bet.has_resolved is False
+
+    _mock_finished_match(direct_vm, "1:0", 1)
+    contract.resolve_bet("2024-06-20_spain_italy")
+
+    assert contract.get_player_points(alice) == 1
+
+
+def test_bet_on_a_far_future_fixture_is_accepted(
+    direct_vm, direct_deploy, direct_alice
+):
+    direct_vm.warp(PRE_MATCH_CLOCK)
+    contract = direct_deploy("contracts/football_bets.py")
+    direct_vm.sender = direct_alice
+    alice = to_hex(direct_alice)
+
+    contract.create_bet("2030-01-15", "Denmark", "England", "0")
+
+    assert "2030-01-15_denmark_england" in contract.get_bets()[alice]
+
+
+def test_create_bet_makes_no_nondeterministic_call(
+    direct_vm, direct_deploy, direct_alice
+):
+    """No web/LLM mock is registered: a nondet call would raise MockNotFoundError."""
+    direct_vm.warp(PRE_MATCH_CLOCK)
+    contract = direct_deploy("contracts/football_bets.py")
+    direct_vm.sender = direct_alice
+    alice = to_hex(direct_alice)
+
+    contract.create_bet(GAME_DATE, "Spain", "Italy", "1")
+
+    assert "2024-06-20_spain_italy" in contract.get_bets()[alice]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The deadline must be computable, or the bet is refused
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "game_date",
+    [
+        "",
+        "20240620",
+        "2024-6-20",
+        "2024-06-20 ",
+        " 2024-06-20",
+        "not-a-date",
+        "2024-06-20T00:00:00Z",
+        "٩٩٩٩-٠١-٠١",  # Arabic-Indic digits
+    ],
+)
+def test_game_date_without_a_computable_deadline_is_rejected(
+    direct_vm, direct_deploy, direct_alice, game_date
+):
+    """The deadline comparison is only sound for a strict ASCII YYYY-MM-DD."""
+    direct_vm.warp(PRE_MATCH_CLOCK)
+    contract = direct_deploy("contracts/football_bets.py")
+    direct_vm.sender = direct_alice
+
+    with direct_vm.expect_revert("Invalid game date"):
+        contract.create_bet(game_date, "Spain", "Italy", "1")
+
+    assert contract.get_bets() == {}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The deadline is measured in UTC, whatever offset the VM writes
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("clock", "utc_date", "next_date"),
+    [
+        pytest.param("2024-06-20T12:00:00Z", "2024-06-20", "2024-06-21", id="zulu"),
+        pytest.param(
+            "2024-06-20T12:00:00z", "2024-06-20", "2024-06-21", id="lowercase-zulu"
+        ),
+        pytest.param(
+            "2024-06-20t12:00:00Z",
+            "2024-06-20",
+            "2024-06-21",
+            id="lowercase-separator",
+        ),
+        pytest.param(
+            "2024-06-20T12:00:00+00:00", "2024-06-20", "2024-06-21", id="zero-offset"
+        ),
+        pytest.param(
+            "2024-06-20T12:00:00.123456Z",
+            "2024-06-20",
+            "2024-06-21",
+            id="fractional-seconds",
+        ),
+        pytest.param(
+            "2024-06-20T12:00:00", "2024-06-20", "2024-06-21", id="naive-read-as-utc"
+        ),
+        pytest.param("2024-06-20", "2024-06-20", "2024-06-21", id="date-only"),
+        pytest.param(
+            "2024-06-19T20:00:00-05:00",
+            "2024-06-20",
+            "2024-06-21",
+            id="negative-offset-rolls-forward",
+        ),
+        pytest.param(
+            "2024-06-19T20:00:00-0500",
+            "2024-06-20",
+            "2024-06-21",
+            id="compact-negative-offset",
+        ),
+        pytest.param(
+            "2024-06-20T01:00:00+02:00",
+            "2024-06-19",
+            "2024-06-20",
+            id="positive-offset-rolls-back",
+        ),
+        pytest.param(
+            "2024-06-30T20:00:00-05:00",
+            "2024-07-01",
+            "2024-07-02",
+            id="month-rollover",
+        ),
+        pytest.param(
+            "2024-12-31T20:00:00-05:00",
+            "2025-01-01",
+            "2025-01-02",
+            id="year-rollover",
+        ),
+        pytest.param(
+            "2024-03-01T01:00:00+02:00",
+            "2024-02-29",
+            "2024-03-01",
+            id="leap-day-rollback",
+        ),
+        pytest.param(
+            "2023-03-01T01:00:00+02:00",
+            "2023-02-28",
+            "2023-03-01",
+            id="non-leap-rollback",
+        ),
+    ],
+)
+def test_deadline_uses_the_utc_date_of_the_transaction(
+    direct_vm, direct_deploy, direct_alice, clock, utc_date, next_date
+):
+    """RFC 3339 allows a UTC offset, so the written date is not always the UTC date.
+
+    Each case pins the boundary from both sides: a fixture on the transaction's
+    own UTC day is closed, and the following day is still open.
+    """
+    direct_vm.warp(clock)
+    contract = direct_deploy("contracts/football_bets.py")
+    direct_vm.sender = direct_alice
+    alice = to_hex(direct_alice)
+
+    with direct_vm.expect_revert("Betting closed for this game"):
+        contract.create_bet(utc_date, "Spain", "Italy", "1")
+
+    contract.create_bet(next_date, "Spain", "Italy", "1")
+
+    assert f"{next_date}_spain_italy" in contract.get_bets()[alice]
+
+
+@pytest.mark.parametrize(
+    "clock",
+    [
+        "",
+        "not-a-timestamp",
+        "2024-06-19X12:00:00Z",
+        "2024-06-19T1:00:00Z",
+        "2024-06-19T25:00:00Z",
+        "2024-06-19T12:60:00Z",
+        "2024-06-19T12:00:00+",
+        "2024-06-19T12:00:00+9:99",
+        "2024-06-19T12:00:00+24:00",
+        "2024-02-30T12:00:00Z",  # 2024 is a leap year, but February has 29 days
+        "2024-13-01T12:00:00Z",
+        "2024-06-00T12:00:00Z",
+    ],
+)
+def test_unusable_transaction_time_fails_closed(
+    direct_vm, direct_deploy, direct_alice, clock
+):
+    """If the deadline cannot be evaluated, creation is refused rather than allowed."""
+    direct_vm.warp(clock)
+    contract = direct_deploy("contracts/football_bets.py")
+    direct_vm.sender = direct_alice
+
+    with direct_vm.expect_revert("Invalid transaction time"):
+        contract.create_bet(GAME_DATE, "Spain", "Italy", "1")
+
+    assert contract.get_bets() == {}

--- a/tests/direct/test_create_bet.py
+++ b/tests/direct/test_create_bet.py
@@ -1,9 +1,10 @@
 """Tests for bet creation logic (no mocks needed — create_bet is deterministic)."""
 
-from tests.direct.conftest import to_hex
+from tests.direct.conftest import PRE_MATCH_CLOCK, to_hex
 
 
 def test_create_bet(direct_vm, direct_deploy, direct_alice):
+    direct_vm.warp(PRE_MATCH_CLOCK)
     contract = direct_deploy("contracts/football_bets.py")
     direct_vm.sender = direct_alice
     alice = to_hex(direct_alice)
@@ -26,6 +27,7 @@ def test_create_bet(direct_vm, direct_deploy, direct_alice):
 
 
 def test_create_multiple_bets(direct_vm, direct_deploy, direct_alice):
+    direct_vm.warp(PRE_MATCH_CLOCK)
     contract = direct_deploy("contracts/football_bets.py")
     direct_vm.sender = direct_alice
     alice = to_hex(direct_alice)
@@ -40,6 +42,7 @@ def test_create_multiple_bets(direct_vm, direct_deploy, direct_alice):
 
 
 def test_create_duplicate_bet_fails(direct_vm, direct_deploy, direct_alice):
+    direct_vm.warp(PRE_MATCH_CLOCK)
     contract = direct_deploy("contracts/football_bets.py")
     direct_vm.sender = direct_alice
 
@@ -52,6 +55,7 @@ def test_create_duplicate_bet_fails(direct_vm, direct_deploy, direct_alice):
 def test_different_users_can_bet_same_match(
     direct_vm, direct_deploy, direct_alice, direct_bob
 ):
+    direct_vm.warp(PRE_MATCH_CLOCK)
     contract = direct_deploy("contracts/football_bets.py")
     alice = to_hex(direct_alice)
     bob = to_hex(direct_bob)
@@ -69,6 +73,7 @@ def test_different_users_can_bet_same_match(
 
 
 def test_bet_id_is_lowercase(direct_vm, direct_deploy, direct_alice):
+    direct_vm.warp(PRE_MATCH_CLOCK)
     contract = direct_deploy("contracts/football_bets.py")
     direct_vm.sender = direct_alice
     alice = to_hex(direct_alice)

--- a/tests/direct/test_resolve_bet.py
+++ b/tests/direct/test_resolve_bet.py
@@ -1,6 +1,6 @@
 """Tests for bet resolution — requires web + LLM mocks."""
 
-from tests.direct.conftest import mock_json_llm, to_hex
+from tests.direct.conftest import PRE_MATCH_CLOCK, mock_json_llm, to_hex
 
 
 def _setup_match_mocks(vm, score, winner):
@@ -17,6 +17,7 @@ def _setup_match_mocks(vm, score, winner):
 
 
 def test_resolve_winning_bet(direct_vm, direct_deploy, direct_alice):
+    direct_vm.warp(PRE_MATCH_CLOCK)
     contract = direct_deploy("contracts/football_bets.py")
     direct_vm.sender = direct_alice
     alice = to_hex(direct_alice)
@@ -36,6 +37,7 @@ def test_resolve_winning_bet(direct_vm, direct_deploy, direct_alice):
 
 
 def test_resolve_losing_bet_no_points(direct_vm, direct_deploy, direct_alice):
+    direct_vm.warp(PRE_MATCH_CLOCK)
     contract = direct_deploy("contracts/football_bets.py")
     direct_vm.sender = direct_alice
     alice = to_hex(direct_alice)
@@ -52,6 +54,7 @@ def test_resolve_losing_bet_no_points(direct_vm, direct_deploy, direct_alice):
 
 
 def test_resolve_draw_bet(direct_vm, direct_deploy, direct_alice):
+    direct_vm.warp(PRE_MATCH_CLOCK)
     contract = direct_deploy("contracts/football_bets.py")
     direct_vm.sender = direct_alice
     alice = to_hex(direct_alice)
@@ -71,6 +74,7 @@ def test_resolve_draw_bet(direct_vm, direct_deploy, direct_alice):
 
 
 def test_resolve_already_resolved_fails(direct_vm, direct_deploy, direct_alice):
+    direct_vm.warp(PRE_MATCH_CLOCK)
     contract = direct_deploy("contracts/football_bets.py")
     direct_vm.sender = direct_alice
 
@@ -84,6 +88,7 @@ def test_resolve_already_resolved_fails(direct_vm, direct_deploy, direct_alice):
 
 
 def test_resolve_unfinished_game_fails(direct_vm, direct_deploy, direct_alice):
+    direct_vm.warp(PRE_MATCH_CLOCK)
     contract = direct_deploy("contracts/football_bets.py")
     direct_vm.sender = direct_alice
 
@@ -96,6 +101,7 @@ def test_resolve_unfinished_game_fails(direct_vm, direct_deploy, direct_alice):
 
 def test_resolve_out_of_range_winner_fails(direct_vm, direct_deploy, direct_alice):
     """An LLM-extracted winner outside {-1, 0, 1, 2} must be rejected, not stored."""
+    direct_vm.warp(PRE_MATCH_CLOCK)
     contract = direct_deploy("contracts/football_bets.py")
     direct_vm.sender = direct_alice
 
@@ -109,6 +115,7 @@ def test_resolve_out_of_range_winner_fails(direct_vm, direct_deploy, direct_alic
 def test_multiple_users_resolve_independently(
     direct_vm, direct_deploy, direct_alice, direct_bob
 ):
+    direct_vm.warp(PRE_MATCH_CLOCK)
     contract = direct_deploy("contracts/football_bets.py")
     alice = to_hex(direct_alice)
     bob = to_hex(direct_bob)

--- a/tests/direct/test_views.py
+++ b/tests/direct/test_views.py
@@ -1,6 +1,6 @@
 """Tests for read-only view methods."""
 
-from tests.direct.conftest import mock_json_llm, to_hex
+from tests.direct.conftest import PRE_MATCH_CLOCK, mock_json_llm, to_hex
 
 
 def test_empty_bets(direct_deploy):
@@ -20,6 +20,7 @@ def test_get_player_points_default_zero(direct_deploy, direct_alice):
 
 
 def test_points_accumulate(direct_vm, direct_deploy, direct_alice):
+    direct_vm.warp(PRE_MATCH_CLOCK)
     contract = direct_deploy("contracts/football_bets.py")
     direct_vm.sender = direct_alice
     alice = to_hex(direct_alice)

--- a/tests/integration/test_new_features.py
+++ b/tests/integration/test_new_features.py
@@ -212,6 +212,9 @@ def test_run_validator_with_football_bets_skips_gracefully(direct_vm, direct_dep
     direct_vm.mock_web(r".*bbc.*", {"status": 200, "body": "Spain 3-0 Italy"})
     direct_vm.mock_llm(r".*", '{"score": "3:0", "winner": 1}')
 
+    # create_bet refuses bets from on/after the match day; warp before deploying
+    # so the contract sees a pre-match transaction time.
+    direct_vm.warp("2024-06-19T12:00:00Z")
     contract = direct_deploy("contracts/football_bets.py")
     contract.create_bet("2024-06-20", "Spain", "Italy", "1")
 
@@ -299,6 +302,9 @@ def test_web_render_text_mode_works(direct_vm, direct_deploy):
     direct_vm.mock_web(r".*bbc.*", {"status": 200, "body": "Spain 3-0 Italy full time"})
     direct_vm.mock_llm(r".*", '{"score": "3:0", "winner": 1}')
 
+    # create_bet refuses bets from on/after the match day; warp before deploying
+    # so the contract sees a pre-match transaction time.
+    direct_vm.warp("2024-06-19T12:00:00Z")
     contract = direct_deploy("contracts/football_bets.py")
     contract.create_bet("2024-06-20", "Spain", "Italy", "1")
 


### PR DESCRIPTION
## Summary

Prevents users from creating football bets after the fixture's betting deadline.

Previously, the finished-match guard in `create_bet()` was commented out, allowing a user to observe a completed result, create a matching bet, and immediately resolve it for a guaranteed point.

This PR adds a deterministic transaction-time deadline check and regression coverage.

## Tests

- Added 40 deadline/validation regression tests
- Full tracked direct test suite passes
- Existing audit reproduction for F-01 now fails with `Betting closed for this game`
- No unrelated audit findings are included

## Scope

This PR addresses F-01 (post-hoc betting) only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added betting-window enforcement: bets must be submitted before the fixture date.
  - Added validation for fixture dates and transaction timestamps.
  - Timestamps are normalized to UTC for consistent deadline handling.
  - Invalid or unusable dates and timestamps are rejected safely.

- **Bug Fixes**
  - Prevented post-match bets from being created or resolved.
  - Preserved acceptance of valid pre-match and future-fixture bets.

- **Tests**
  - Added comprehensive coverage for deadlines, malformed dates, timezone offsets, and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->